### PR TITLE
Add 1.17 compatibility

### DIFF
--- a/workspaces/Twingate Chrome/workspace.json
+++ b/workspaces/Twingate Chrome/workspace.json
@@ -32,6 +32,11 @@
       "version": "1.16.x",
       "image": "europe-west2-docker.pkg.dev/twingate-labs/tg-agentless-images/tg-chrome:dev",
       "uncompressed_size_mb": 2170
+    },
+    {
+      "version": "1.17.x",
+      "image": "europe-west2-docker.pkg.dev/twingate-labs/tg-agentless-images/tg-chrome:dev",
+      "uncompressed_size_mb": 2170
     }
   ]
 }

--- a/workspaces/Twingate Desktop/workspace.json
+++ b/workspaces/Twingate Desktop/workspace.json
@@ -34,6 +34,11 @@
       "version": "1.16.x",
       "image": "europe-west2-docker.pkg.dev/twingate-labs/tg-agentless-images/tg-desktop:dev",
       "uncompressed_size_mb": 7660
+    },
+    {
+      "version": "1.17.x",
+      "image": "europe-west2-docker.pkg.dev/twingate-labs/tg-agentless-images/tg-desktop:dev",
+      "uncompressed_size_mb": 7660
     }
   ]
 }


### PR DESCRIPTION
Add 1.17 compatibility to the Twingate workspaces so that it will both work on 1.17 and display the spotlight.